### PR TITLE
Read nexus listen port from env vars

### DIFF
--- a/nexus.py
+++ b/nexus.py
@@ -7,6 +7,9 @@ import numpy as np
 import pickle
 
 
+nexus_port = int(os.getenv('NEXUS_PORT', 8888))
+
+
 log = logging.getLogger('werkzeug')
 log.setLevel(logging.ERROR)
 app = flask.Flask('nexus')
@@ -127,4 +130,4 @@ if __name__ == '__main__':
     except Exception as oops:
         print(oops)
         data = list()
-    app.run(host='0.0.0.0', port=8888)
+    app.run(host='0.0.0.0', port=nexus_port)


### PR DESCRIPTION
Small change to read the nexus listening port from environment variables instead of hardcoding it.

This small change helps when running the services decoupled (like in containers environments) and at same time is not so intrusive with your work.

Hope it helps.
